### PR TITLE
Allow install on non-windows platforms

### DIFF
--- a/install.js
+++ b/install.js
@@ -18,8 +18,7 @@ var downloadUrl = 'http://download.microsoft.com/download/1/4/1/14156DA0-D40F-46
 var platform = process.platform
 
 if (platform !== 'win32') {
-  console.log('EdgeDriverServer only works on Windows:', process.platform, process.arch)
-  process.exit(1)
+  console.warn('NOTE: EdgeDriverServer only works on Windows, you are using:', process.platform, process.arch)
 }
 
 var fileName = 'MicrosoftWebDriver.exe';


### PR DESCRIPTION
The edge driver seems to work in my testing, but I can't add it to my project (which is developed on mac and runs on windows) because of this error.

It seems harmless to install anywhere - your [node-iedriver](https://github.com/barretts/node-iedriver) project doesn't block installation in this way, so I'm hoping there are no barriers to changing edgedriver to do the same :)